### PR TITLE
Add support for multiple api urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /appenv/
 /__pycache__/
+venv/
+.idea/
 *.sublime*
 *.log

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Insert following (example):
 
 ```
 [API]
-API_URL = ["http://127.0.0.1:8841/", "http://127.0.0.2:8841/"]
+API_URL = http://127.0.0.1:8841/ http://127.0.0.2:8841/
 
 [NODE]
 PUB_KEY = Mpd30a965324ffd01c3b61e898137bd6eacd69243b43512ab1dde1deca697f39ad

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Insert following (example):
 
 ```
 [API]
-API_URL = http://127.0.0.1:8841/
+API_URL = ["http://127.0.0.1:8841/", "http://127.0.0.2:8841/"]
 
 [NODE]
 PUB_KEY = Mpd30a965324ffd01c3b61e898137bd6eacd69243b43512ab1dde1deca697f39ad
@@ -98,11 +98,11 @@ MISSED_BLOCKS = 3
 LOG = /home/minter-guard/minter-guard.log
 ```
 Note, that you **MUST** provide correct:
-1. API node address.
+1. API nodes address.
 2. PUB_KEY of your node.
 3. MISSED_BLOCKS. This is trigger parameter to execute OFF_TX transaction. Note, that after execution of TX, your node will MISS _at least_ 2 next blocks.
 
-API node **MUST** be synced to network **COMPLETELY**.
+API nodes **MUST** be synced to network **COMPLETELY**.
 Provided txgenerator uses API node to get nonce for OFF_TX
 
 ### Generate OFF_TX

--- a/minterguard/.config
+++ b/minterguard/.config
@@ -1,5 +1,5 @@
 [API]
-API_URL = http://127.0.0.1:8841/
+API_URL = ["http://127.0.0.1:8841/", "http://127.0.0.2:8841/"]
 
 [NODE]
 PUB_KEY = Mpd30a965324ffd01c3b61e898137bd6eacd69243b43512ab1dde1deca697f39ad

--- a/minterguard/.config
+++ b/minterguard/.config
@@ -1,5 +1,5 @@
 [API]
-API_URL = ["http://127.0.0.1:8841/", "http://127.0.0.2:8841/"]
+API_URL = http://127.0.0.1:8841/ http://127.0.0.2:8841/
 
 [NODE]
 PUB_KEY = Mpd30a965324ffd01c3b61e898137bd6eacd69243b43512ab1dde1deca697f39ad

--- a/minterguard/guard.py
+++ b/minterguard/guard.py
@@ -16,7 +16,6 @@ import logging
 import sys
 import time
 import os
-import json
 
 from mintersdk.minterapi import MinterAPI
 from mintersdk.sdk.transactions import MinterTx, MinterSetCandidateOffTx
@@ -173,9 +172,9 @@ if __name__ == '__main__':
                     raise Exception('Section {} not found'.format(section))
 
             # Check sections attributes
-            if config['API'].get('API_URLS') is None or \
-               config['API']['API_URLS'] == '':
-                raise Exception('API_URLS should be provided')
+            if config['API'].get('API_URL') is None or \
+               config['API']['API_URL'] == '':
+                raise Exception('API_URL should be provided')
 
             if config['NODE'].get('PUB_KEY') is None or \
                config['NODE']['PUB_KEY'] == '':
@@ -187,7 +186,7 @@ if __name__ == '__main__':
 
             # Set kwargs
             kwargs.update({
-                'api_urls': json.loads(config['API']['API_URLS']),
+                'api_urls': config['API']['API_URL'].split(),
                 'pub_key': config['NODE']['PUB_KEY'],
                 'set_off_tx': config['NODE']['SET_OFF_TX']
             })

--- a/minterguard/guard.py
+++ b/minterguard/guard.py
@@ -87,7 +87,9 @@ class Guard(object):
             try:
                 # Get missed blocks
                 response = None
-                for minterapi in self.minterapis:
+                for i, minterapi in enumerate(self.minterapis):
+                    if i > 0:
+                        logger.info('{} attempt with {} API'.format(i, minterapi.api_url))
                     try:
                         response = minterapi.get_missed_blocks(self.pub_key)
                         break

--- a/minterguard/txgenerator.py
+++ b/minterguard/txgenerator.py
@@ -10,8 +10,10 @@ Script accepts 2 required arguments:
 """
 
 import sys
+import json
 import getpass
 import configparser
+
 from mintersdk.minterapi import MinterAPI
 from mintersdk.sdk.transactions import (MinterSetCandidateOnTx,
                                         MinterSetCandidateOffTx)
@@ -28,13 +30,13 @@ if __name__ == '__main__':
     config = configparser.ConfigParser()
     config.read(sys.argv[1])
 
-    # Try to get API url
+    # Try to get API urls
     try:
-        api_url = config['API']['API_URL'].strip()
-        if api_url == '':
+        api_urls = json.loads(config['API']['API_URLS'])
+        if len(api_urls) == 0:
             raise
     except Exception:
-        print('API_URL is not set in config file')
+        print('API_URLS is not set in config file')
         sys.exit(1)
 
     # Try to get pub key
@@ -57,15 +59,29 @@ if __name__ == '__main__':
 
     # When all data seems to be set, create txs
     try:
-        # Get API and wallet
-        minterapi = MinterAPI(api_url)
+        # Get APIs
+        minterapis = [MinterAPI(api_url) for api_url in api_urls]
+
+        # Get wallet
         wallet = MinterWallet.create(mnemonic=seed)
+
+        # Get nonce from API
+        nonce = None
+        for minterapi in minterapis:
+            try:
+                nonce = minterapi.get_nonce(address=wallet['address'])
+                break
+            except Exception as e:
+                print(e.__str__())
+
+        if nonce is None:
+            raise
 
         if action == 'on':
             # Set candidate on tx
             tx = MinterSetCandidateOnTx(
                 pub_key=pub_key,
-                nonce=minterapi.get_nonce(address=wallet['address']),
+                nonce=nonce,
                 gas_coin='BIP'
             )
             tx.sign(wallet['private_key'])
@@ -74,7 +90,7 @@ if __name__ == '__main__':
             # Set candidate off tx
             tx = MinterSetCandidateOffTx(
                 pub_key=pub_key,
-                nonce=minterapi.get_nonce(address=wallet['address']),
+                nonce=nonce,
                 gas_coin='BIP'
             )
             tx.sign(wallet['private_key'])

--- a/minterguard/txgenerator.py
+++ b/minterguard/txgenerator.py
@@ -10,7 +10,6 @@ Script accepts 2 required arguments:
 """
 
 import sys
-import json
 import getpass
 import configparser
 
@@ -32,11 +31,11 @@ if __name__ == '__main__':
 
     # Try to get API urls
     try:
-        api_urls = json.loads(config['API']['API_URLS'])
+        api_urls = config['API']['API_URL'].split()
         if len(api_urls) == 0:
             raise
     except Exception:
-        print('API_URLS is not set in config file')
+        print('API_URL is not set in config file')
         sys.exit(1)
 
     # Try to get pub key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-minter-sdk (https://github.com/U-node/minter-sdk)
+configparser
+git+https://github.com/U-node/minter-sdk


### PR DESCRIPTION
Так как заданное в конфиге единственное API может быть по разным причинам недоступно (даже если это балансер), добавил поддержку нескольких API - в конфиге теперь можно указать список API endpoint-ов.

Теперь при всех запросах к API в случае недоступности одного из них будет использоваться следующее по списку итд. Это делает систему гораздо более отказоустойчивой.